### PR TITLE
feat(home/news): 개인화 뉴스 섹션 도입 및 UI 리뉴얼

### DIFF
--- a/my_app/ui/home/home.py
+++ b/my_app/ui/home/home.py
@@ -93,5 +93,3 @@ def render():
         html('<div class="arrow-col">←</div>')
     with row2[0]:
         render_link_card("종목 피드백", "관심 종목별로 세부 피드백을 받아 전략을 개선하세요.", "📊", PAGE_KEYS["종목 피드백"])
-
-    st.divider()

--- a/my_app/ui/home/profile_panel.py
+++ b/my_app/ui/home/profile_panel.py
@@ -97,26 +97,49 @@ def render_emotion_card(emotions, score_map=None, size_in=3.8):
     set_korean_font()
 
     axes = ["신중함","불안","아쉬움","혼란","자신감","욕심"]
+    synonyms = {
+        "신중함": {"신중함","침착함","차분함","현실성"},
+        "불안": {"불안","불안감","초조","걱정"},
+        "아쉬움": {"아쉬움","후회"},
+        "혼란": {"혼란","동요","갈등"},
+        "자신감": {"자신감","희망","기대감","도전","적극성"},
+        "욕심": {"욕심","욕구","탐욕"},
+    }
+
+    def _norm(x): 
+        try: return max(0.0, min(1.0, float(x)))
+        except: return 0.0
+
+    emo_list = emotions or []
     scores = []
     for k in axes:
-        if score_map and k in score_map: v = float(score_map[k])
-        else: v = 0.6 if (emotions and any(k in e for e in emotions)) else 0.25
-        scores.append(max(0.0, min(1.0, v)))
+        if score_map and k in score_map:
+            v = _norm(score_map[k])
+        else:
+            # 감정 단어가 동의어에 몇 개나 걸리는지로 강도 추정 (0.35/0.55/0.75)
+            hit = sum(1 for e in emo_list for syn in synonyms[k] if syn in str(e))
+            v = 0.35 + min(hit, 2) * 0.20
+        scores.append(_norm(v))
+
     vals = scores + [scores[0]]
     angs = np.linspace(0, 2*np.pi, len(axes)+1)
 
-    fig = plt.figure(figsize=(size_in, size_in), dpi=170)  # 정사각형
+    fig = plt.figure(figsize=(size_in, size_in), dpi=220)
     ax = fig.add_subplot(111, polar=True)
-    ax.plot(angs, vals, linewidth=2)
-    ax.fill(angs, vals, alpha=0.18)
-    ax.set_thetagrids(angs[:-1]*180/np.pi, axes, fontsize=10)
-    ax.set_rgrids([0.25,0.5,0.75,1.0], angle=0, fontsize=9)
-    ax.set_ylim(0,1); ax.grid(True, linestyle="--", alpha=0.35)
-    fig.tight_layout()
+    ax.set_position([0.04, 0.04, 0.92, 0.92])   # 원 영역 크게
 
-    buf = io.BytesIO(); fig.savefig(buf, format="png", dpi=170, bbox_inches="tight", facecolor="white")
+    ax.plot(angs, vals, linewidth=2.2)
+    ax.fill(angs, vals, alpha=0.18)
+    ax.set_thetagrids(angs[:-1]*180/np.pi, axes, fontsize=40)  # 글씨 키움
+    ax.tick_params(axis="x", pad=30) 
+    ax.set_ylim(0, 1)
+    ax.grid(True, linestyle="--", alpha=0.35)
+
+    buf = io.BytesIO()
+    fig.savefig(buf, format="png", dpi=190, bbox_inches="tight", facecolor="white")
     plt.close(fig)
     return base64.b64encode(buf.getvalue()).decode("ascii")
+
 
 
 def render_user_panel():
@@ -177,21 +200,19 @@ def render_user_panel():
       <div class="p-body">
         <div class="sq-row">
             <div class="square-card emotion-card">
+              <div class="card-head">리스크 허용도</div>
               <div class="sq-inner">
                 <div class="ring lg" style="--p:{risk};"><div class="v">{risk}%</div></div>
-                <div>
-                  <div class="sq-title">리스크 허용도</div>
-                  <div class="muted">현재 설정된 위험 허용 수준입니다.</div>
-                </div>
               </div>
             </div>
-              <div class="square-card emotion-card">
-                <img class="radar-img"
-                    src="data:image/png;base64,{render_emotion_card(
-                          emotions,
-                          score_map=profile.get('investment_emotions_score'),
-                          size_in=6.0)}" alt="감정분석"/>
-                <div class="sq-rail-title">감정분석</div>
+            <div class="square-card emotion-card">
+              <div class="card-head">감정분석</div>
+              <img class="radar-img"
+                  src="data:image/png;base64,{render_emotion_card(
+                        emotions,
+                        score_map=profile.get('investment_emotions_score'),
+                        size_in=6.0)}"
+                  alt="감정분석"/>
             </div>
           </div>
       </div>     <!-- /.p-body -->

--- a/my_app/ui/home/styles.py
+++ b/my_app/ui/home/styles.py
@@ -167,7 +167,11 @@ def inject_home_styles():
         gap:10px;
         text-decoration: none;   /* 밑줄 제거 */        
       }
-      @media (max-width: 1100px){ .news-grid{ grid-template-columns:1fr; } }
+      @media (max-width: 1100px){
+        .sq-row{ grid-template-columns: 1fr; }
+        .sq-inner .ring{ --size: clamp(120px, 38vw, 180px); --thick: 20px; }
+        .emotion-card .radar-img{ max-width: clamp(200px, 60vw, 420px); }
+      }
 
       .news-card{
         display:block;
@@ -259,45 +263,74 @@ def inject_home_styles():
         border:1px solid var(--border);
         border-radius:16px;
         background:#fff;
-        padding:16px;
-        aspect-ratio: 1 / 1;         /* 정사각형 유지 */
+        padding:18px;
+        min-height: 300px;          /* 너무 낮지 않게만 */
+        display:flex; align-items:center; justify-content:center;
       }
 
       /* 감정 카드: 왼쪽에 그래프, 오른쪽 좁은 타이틀 레일 */
       .emotion-card{
+        display:flex; align-items:center; justify-content:space-between; width:100%;
+      }
+                
+      /* --- 카드 상단 제목 공통 --- */
+      .card-head{
+        width:100%;
+        font-weight:800;
+        /* 글씨 크기 업 */
+        font-size: clamp(1.0rem, 1.3vw, 1.35rem);
+        color: var(--ink);
+        margin-bottom: 10px;
+      }
+
+      /* 리스크 카드: 제목은 위, 도넛과 설명은 아래 가로배치 */
+      .square-card.risk-card{
+        display:flex; flex-direction:column; align-items:flex-start;
+      }
+      .square-card.risk-card .sq-inner{
+        width:100%;
+        display:flex; align-items:center; gap:16px;
+      }
+      .square-card.risk-card .ring{
+        /* 크기 살짝 줄여 반반 느낌 유지 */
+        --size: clamp(140px, 20vw, 190px);
+        --thick: 24px;
+        width: var(--size); height: var(--size);
+        border-radius:50%;
+        background: conic-gradient(var(--accent) calc(var(--p)*1%), #e2e8f0 0);
+        position: relative;
+      }
+      .square-card.risk-card .ring::before{ content:""; position:absolute; inset: var(--thick); border-radius:50%; background:#fff; }
+      .square-card.risk-card .ring .v{ position:absolute; inset:0; display:grid; place-items:center; font-weight:900; }
+
+      /* 감정분석 카드: 제목을 위 가로, 그래프는 크게 중앙 */
+      .square-card.emotion-card{
         display:grid;
-        grid-template-columns: 1fr 56px; /* 오른쪽 제목 레일 폭 */
+        grid-template-rows: auto 1fr;
+        grid-template-columns: 1fr;
         align-items:center;
       }
-
-      /* 그래프 이미지 크게 보이도록 */
+      .square-card.emotion-card .card-head{
+        grid-row:1; grid-column:1; justify-self:start;
+      }
+      .square-card.emotion-card .radar-img{
+        grid-row:2; grid-column:1; justify-self:center;
+        /* 그래프 조금 더 키움 */
+        max-width: clamp(280px, 40vw, 560px);
+        height:auto;
+      }
       .emotion-card .radar-img{
-        width: 94%;
-        max-width: 560px;            /* 필요시 600까지 */
-        height: auto;
-        justify-self: center;
-        display: block;
-        margin: 0 auto;
+        flex:1 1 auto;
+        max-width: clamp(220px, 34vw, 460px);   /* 화면에 맞게 반응형 */
+        height:auto;
       }
-
-      /* 오른쪽 세로제목(한국어 세로쓰기) */
-      .sq-rail-title{
-        writing-mode: vertical-rl;   /* 세로 레일 */
-        text-orientation: mixed;
-        font-weight: 800;
-        letter-spacing: .08em;
-        color: var(--ink);
-        justify-self: end;
-        user-select: none;
-      }
-
-      /* (수평으로 두고 싶으면)
-      .sq-rail-title{ writing-mode: horizontal-tb; transform: rotate(90deg); } */
+      /* 세로 레일(감정분석 글자) */
+      .sq-rail-title{ display:none !important; }
 
 
       /* 카드 안 레이아웃 */
       .sq-inner{
-        display:flex; align-items:center; justify-content:center; gap:16px;
+        display:flex; align-items:center; gap:16px;
       }
       .sq-inner.col{ flex-direction:column; }
 
@@ -306,24 +339,26 @@ def inject_home_styles():
 
       /* 큰 도넛 */
       .ring{
-        --p:0; --size:220px; --thick:20px;
+        --p:0; --size:260px; --thick:28px;
         width: var(--size);
-        aspect-ratio: 1 / 1;     /* 정사각 비율 고정 */
-        height: auto;
-        border-radius: 50%;
+        height: var(--size);
+        border-radius:50%;
         background: conic-gradient(var(--accent) calc(var(--p)*1%), #e2e8f0 0);
         position: relative;
-
-        /* 정렬 */
-        justify-self: start;     /* grid일 때 왼쪽 */
-        align-self: center;      /* 세로 중앙 */
       }
-      .ring::before{
-        content:"";
-        position:absolute; inset: var(--thick);
-        border-radius:50%; background:#fff;
+      .sq-inner .ring{
+        /* 화면에 따라: 최소 140px ~ 최대 200px */
+        --size: clamp(140px, 22vw, 200px);
+        --thick: 24px;
+        width: var(--size);
+        height: var(--size);
+        border-radius:50%;
+        background: conic-gradient(var(--accent) calc(var(--p)*1%), #e2e8f0 0);
+        position: relative;
+        flex: 0 0 auto;          /* 텍스트 영역과 반반 느낌 */
       }
-      .ring .v{ position:absolute; inset:0; display:grid; place-items:center; }
+      .ring::before{ content:""; position:absolute; inset: var(--thick); border-radius:50%; background:#fff; }
+      .ring .v{ position:absolute; inset:0; display:grid; place-items:center; font-weight:900; }
 
       /* 레이더 이미지가 카드 안에서 깔끔히 보이게 */
       .radar-img{
@@ -335,6 +370,9 @@ def inject_home_styles():
         margin: 4px auto 0;
       }
                 
+      
+                
+
       
 
     </style>

--- a/my_app/ui/home/styles.py
+++ b/my_app/ui/home/styles.py
@@ -165,6 +165,7 @@ def inject_home_styles():
         display:grid;
         grid-template-columns: 1fr 1fr;
         gap:10px;
+        text-decoration: none;   /* 밑줄 제거 */        
       }
       @media (max-width: 1100px){ .news-grid{ grid-template-columns:1fr; } }
 
@@ -182,6 +183,8 @@ def inject_home_styles():
         transform: translateY(-2px);
         box-shadow:0 10px 22px rgba(2,6,23,.10);
         border-color: rgba(37,99,235,.35);
+        color: var(--accent2);   /* 호버 시 색만 변하도록 */
+        text-decoration: none;   /* 호버 때도 밑줄 X */
       }
       .news-tag{
         display:inline-flex; align-items:center; gap:6px;
@@ -194,13 +197,35 @@ def inject_home_styles():
         margin-bottom:6px;
       }
       .news-title{
-        font-weight:800; line-height:1.35; margin:2px 0 4px 0; font-size:.98rem;
+        font-weight:800; line-height:1.35; margin:2px 0 4px 0; font-size:.98rem; text-decoration: none;
       }
       .news-meta{
-        font-size:.86rem; color:var(--muted);
-      }``
+        font-size:.86rem; color:var(--muted);  color:var(--muted);
+      }
+                
+      .news-grid a,
+      .news-card,
+      .news-card:link,
+      .news-card:visited,
+      .news-card:hover,
+      .news-card:active {
+        text-decoration: none !important;
+        border-bottom: none !important; /* 일부 테마가 밑줄 대신 border-bottom 사용 */
+        outline: none;
+        color: var(--ink);
+      }
 
+      .news-card * {
+        text-decoration: none !important; /* 앵커 내부 모든 자식에도 강제 */
+        border-bottom: none !important;
+      }
 
+      .news-title {
+        font-weight:800; line-height:1.35; margin:2px 0 4px 0; font-size:.98rem;
+        color: var(--ink); text-decoration: none !important;
+      }
+      .news-card:hover .news-title { color: var(--accent2); }
+    
       /* floating toast */
       .floating-wrap{position:fixed;right:22px;bottom:22px;z-index:9999;width:360px;max-width:calc(100vw - 40px)}
       .ft-hide{position:absolute;opacity:0;pointer-events:none}

--- a/my_app/ui/home/styles.py
+++ b/my_app/ui/home/styles.py
@@ -196,9 +196,6 @@ def inject_home_styles():
         border:1px solid rgba(37,99,235,.18);
         margin-bottom:6px;
       }
-      .news-title{
-        font-weight:800; line-height:1.35; margin:2px 0 4px 0; font-size:.98rem; text-decoration: none;
-      }
       .news-meta{
         font-size:.86rem; color:var(--muted);  color:var(--muted);
       }


### PR DESCRIPTION
## 주요 기능

* user\_id로 Supabase user\_news\_logs 조회 후 카드 렌더(요약, 핵심기회, 잠재리스크, 애널리스트 의견, 관련링크)
* user\_id 없거나 데이터 없을 때 빈 상태 안내 및 공개 뉴스 폴백(RSS)
* 홈 뉴스 UI 개선: 배지, 칩, 타임스탬프, 헤더, 목록 가독성

## 변경사항
* 임시 일반 뉴스 제거, 개인화 추천으로 전환
* ui/home/news\_panel.py에 fetch\_news\_by\_user\_id, render\_news\_list 추가
* fetch\_latest\_news 정리, 폴백 로직 통합
* 유틸 추가: \_parse\_array, \_parse\_links
* 스타일 보강

## 테스트

* [x] 개인화 카드 노출 확인
* [x] user\_id 미존재 시 빈 상태 안내
* [x] 개인화 데이터 미존재 시 폴백 동작
* [x] 링크/칩 클릭 및 새 탭 열림
* [x] 긴 텍스트 줄바꿈/오버플로우 처리
